### PR TITLE
Improve HF integration

### DIFF
--- a/nets/net34.py
+++ b/nets/net34.py
@@ -6,7 +6,14 @@ import numpy as np
 
 from nets.blocks import CNBlockConfig, ConvNeXt, conv1x1, RelUpdateBlock, InputPadder, CorrBlock, BasicEncoder
 
-class Net(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class Net(nn.Module, PyTorchModelHubMixin,
+          repo_url="https://github.com/aharley/alltracker",
+          paper_url="https://huggingface.co/papers/2506.07310",
+          tags=["tracking"],
+          license="mit"):
     def __init__(
             self,
             seqlen,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn==1.5.2
 scikit-image==0.24.0
 tensorboardX==2.6.2.2
 prettytable==3.12.0
+huggingface-hub==0.33.1


### PR DESCRIPTION
This PR showcases the [PyTorchModelHubMixin](https://huggingface.co/docs/hub/models-uploading#upload-a-pytorch-model-using-huggingfacehub) class which you could use to push and reload the AllTracker models to and from the hub.

Here's the model: https://huggingface.co/nielsr/alltracker.

Usage is as follows:

```python
from nets.net34 import Net

model = Net.from_pretrained("nielsr/alltracker")
```

Benefits:
- download stats work
- the weights are serialized in the safetensors format (along with a config.json)
- you can tweak the model card, but there's a default one
- each checkpoint gets pushed to a separate model repository (best practice).